### PR TITLE
Adds the bind-to-interface helper code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,11 @@ repository = "https://github.com/krolaw/dhcp4r"
 keywords = ["dhcp", "server", "monitor", "client"]
 license = "BSD-3-Clause"
 
+[features]
+default = ["linux-udp-helper"]
+linux-udp-helper = ["net2", "libc"]
+
 [dependencies]
 time = "0.1"
+net2 = { version = "^0.2", optional = true }
+libc = { version = "^0.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "linux-udp-helper")]
+extern crate net2;
+#[cfg(feature = "linux-udp-helper")]
+extern crate libc;
+
 pub mod options;
 pub mod packet;
 pub mod server;


### PR DESCRIPTION
Typical UDP socket would listen on 0.0.0.0:67 and bind to an interface
to limit exposure. This PR implements a helper method to bind and serve
on a socket.

Currently it’s linux only. I left an unimplemented!() trap for BSD with
a note how to progress there and feature-gated the code.