### PR TITLE
Improve use of Rust types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ keywords = ["dhcp", "server", "monitor", "client"]
 license = "BSD-3-Clause"
 
 [dependencies]
+enum-primitive-derive = "^0.1"
+num-traits = "^0.1"
 time = "0.1"

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -13,7 +13,7 @@ struct MyServer {}
 impl server::Handler for MyServer {
     fn handle_request(&mut self, _: &server::Server, in_packet: packet::Packet) {
         match in_packet.message_type() {
-            dhcp4r::REQUEST => {
+            Ok(options::MessageType::Request) => {
                 let req_ip = match in_packet.option(options::REQUESTED_IP_ADDRESS) {
                     None => in_packet.ciaddr,
                     Some(x) => {

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -11,8 +11,8 @@ fn main() {
 struct MyServer {}
 
 impl server::Handler for MyServer {
-    fn handle_request(&mut self, _: &server::Server, msg_type: u8, in_packet: packet::Packet) {
-        match msg_type {
+    fn handle_request(&mut self, _: &server::Server, in_packet: packet::Packet) {
+        match in_packet.message_type() {
             dhcp4r::REQUEST => {
                 let req_ip = match in_packet.option(options::REQUESTED_IP_ADDRESS) {
                     None => in_packet.ciaddr,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -43,9 +43,8 @@ struct MyServer {
 impl server::Handler for MyServer {
     fn handle_request(&mut self,
                       server: &server::Server,
-                      msg_type: u8,
                       in_packet: packet::Packet) {
-        match msg_type {
+        match in_packet.message_type() {
             dhcp4r::DISCOVER => {
                 // Prefer client's choice if available
                 if let Some(r) = in_packet.option(options::REQUESTED_IP_ADDRESS) {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -134,19 +134,19 @@ impl MyServer {
 
 fn reply(s: &server::Server, msg_type: u8, req_packet: packet::Packet, offer_ip: [u8; 4]) {
     let _ = s.reply(msg_type,
-                    vec![options::Option {
+                    vec![options::DhcpOption {
                              code: options::IP_ADDRESS_LEASE_TIME,
                              data: &LEASE_DURATION_BYTES,
                          },
-                         options::Option {
+                         options::DhcpOption {
                              code: options::SUBNET_MASK,
                              data: &SUBNET_MASK,
                          },
-                         options::Option {
+                         options::DhcpOption {
                              code: options::ROUTER,
                              data: &ROUTER_IP,
                          },
-                         options::Option {
+                         options::DhcpOption {
                              code: options::DOMAIN_NAME_SERVER,
                              data: &DNS_IPS,
                          }],
@@ -156,7 +156,7 @@ fn reply(s: &server::Server, msg_type: u8, req_packet: packet::Packet, offer_ip:
 
 fn nak(s: &server::Server, req_packet: packet::Packet, message: &[u8]) {
     let _ = s.reply(dhcp4r::NAK,
-                    vec![options::Option {
+                    vec![options::DhcpOption {
                              code: options::MESSAGE,
                              data: message,
                          }],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#[macro_use]
+extern crate enum_primitive_derive;
+extern crate num_traits;
+
 pub mod options;
 pub mod packet;
 pub mod server;
@@ -17,17 +21,6 @@ macro_rules! bytes_u32 {
         ($x[0] as u32) * (1 << 24) + ($x[1] as u32) * (1 << 16) + ($x[2] as u32) * (1 << 8) + ($x[3] as u32)
     };
 }
-
-// DHCP Message Type 53;
-pub const DISCOVER: u8 = 1; // Broadcast Packet From Client - Can I have an IP?
-pub const OFFER: u8 = 2; // Broadcast From Server - Here's an IP
-pub const REQUEST: u8 = 3; // Broadcast From Client - I'll take that IP (Also start for renewals)
-pub const DECLINE: u8 = 4; // Broadcast From Client - Sorry I can't use that IP
-pub const ACK: u8 = 5; // From Server, Yes you can have that IP
-pub const NAK: u8 = 6; // From Server, No you cannot have that IP
-pub const RELEASE: u8 = 7; // From Client, I don't need that IP anymore
-pub const INFORM: u8 = 8; // From Client, I'd like some other information
-
 
 #[cfg(test)]
 mod tests {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,3 +1,5 @@
+use num_traits::FromPrimitive;
+
 pub struct DhcpOption<'a> {
     pub code: u8,
     pub data: &'a [u8],
@@ -220,4 +222,25 @@ pub fn title(code: u8) -> Option<&'static str> {
 
         _ => return None,
     })
+}
+
+///
+/// DHCP Message Type (option code 53)
+///
+#[derive(Primitive)]
+pub enum MessageType {
+    Discover = 1,
+    Offer = 2,
+    Request = 3,
+    Decline = 4,
+    Ack = 5,
+    Nak = 6,
+    Release = 7,
+    Inform = 8,
+}
+
+impl MessageType {
+    pub fn from(val: u8) -> Result<MessageType, String> {
+        MessageType::from_u8(val).ok_or_else(|| format!["Invalid DHCP Message Type: {:?}", val])
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -225,17 +225,45 @@ pub fn title(code: u8) -> Option<&'static str> {
 }
 
 ///
-/// DHCP Message Type (option code 53)
+/// DHCP Message Type.
+///
+/// # Standards
+///
+/// The semantics of the various DHCP message types are described in RFC 2131 (see Table 2).
+/// Their numeric values are described in Section 9.6 of RFC 2132, which begins:
+///
+/// > This option is used to convey the type of the DHCP message.  The code for this option is 53,
+/// > and its length is 1.
 ///
 #[derive(Primitive)]
 pub enum MessageType {
+    /// Client broadcast to locate available servers.
     Discover = 1,
+
+    /// Server to client in response to DHCPDISCOVER with offer of configuration parameters.
     Offer = 2,
+
+    /// Client message to servers either (a) requesting offered parameters from one server and
+    /// implicitly declining offers from all others, (b) confirming correctness of previously
+    /// allocated address after, e.g., system reboot, or (c) extending the lease on a particular
+    /// network address.
     Request = 3,
+
+    /// Client to server indicating network address is already in use.
     Decline = 4,
+
+    /// Server to client with configuration parameters, including committed network address.
     Ack = 5,
+
+    /// Server to client indicating client's notion of network address is incorrect (e.g., client
+    /// has moved to new subnet) or client's lease as expired.
     Nak = 6,
+
+    /// Client to server relinquishing network address and cancelling remaining lease.
     Release = 7,
+
+    /// Client to server, asking only for local configuration parameters; client already has
+    /// externally configured network address.
     Inform = 8,
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,11 +1,9 @@
-use std;
-
-pub struct Option<'a> {
+pub struct DhcpOption<'a> {
     pub code: u8,
     pub data: &'a [u8],
 }
 
-impl<'a> Option<'a> {
+impl<'a> DhcpOption<'a> {
     /// Returns name of DHCP Option code
     pub fn title(&'a self) -> String {
         match title(self.code) {
@@ -116,7 +114,7 @@ pub const TZ_DATABASE_STRING: u8 = 101;
 pub const CLASSLESS_ROUTE_FORMAT: u8 = 121;
 
 /// Returns title of DHCP Option code, if known.
-pub fn title(code: u8) -> std::option::Option<&'static str> {
+pub fn title(code: u8) -> Option<&'static str> {
     Some(match code {
         SUBNET_MASK => "Subnet Mask",
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -14,7 +14,7 @@ pub struct Packet<'a> {
     pub siaddr: [u8; 4],
     pub giaddr: [u8; 4],
     pub chaddr: [u8; 6],
-    pub options: Vec<Option<'a>>,
+    pub options: Vec<DhcpOption<'a>>,
 }
 
 /// Parses Packet from byte array
@@ -41,7 +41,7 @@ pub fn decode(p: &[u8]) -> Result<Packet, &'static str> {
             if i + 2 < l {
                 let opt_end = (p[i + 1]) as usize + i + 2;
                 if opt_end < l {
-                    options.push(Option {
+                    options.push(DhcpOption {
                         code: code,
                         data: &p[i + 2..opt_end],
                     });
@@ -69,7 +69,7 @@ pub fn decode(p: &[u8]) -> Result<Packet, &'static str> {
 
 impl<'a> Packet<'a> {
     /// Extracts requested option payload from packet if available
-    pub fn option(&self, code: u8) -> std::option::Option<&'a [u8]> {
+    pub fn option(&self, code: u8) -> Option<&'a [u8]> {
         for option in &self.options {
             if option.code == code {
                 return Some(&option.data);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,5 +1,3 @@
-use std;
-
 use options::*;
 
 /// DHCP Packet Structure
@@ -79,13 +77,16 @@ impl<'a> Packet<'a> {
     }
 
     /// Convenience function for extracting a packet's message type.
-    pub fn message_type(&self) -> u8 {
+    pub fn message_type(&self) -> Result<MessageType, String> {
         if let Some(x) = self.option(DHCP_MESSAGE_TYPE) {
-            if x.len() > 0 {
-                return x[0];
+            if x.len() != 1 {
+                Err(format!["Invalid length for DHCP MessageType: {}", x.len()])
+            } else {
+                MessageType::from(x[0])
             }
+        } else {
+            Err(format!["Packet does not have MessageType option"])
         }
-        0
     }
 
     /// Creates byte array DHCP packet

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,6 +2,7 @@ use std::net::{UdpSocket, SocketAddr, Ipv4Addr, IpAddr};
 use std;
 use std::cell::Cell;
 
+use options::DhcpOption;
 use packet::*;
 use options;
 use NAK;
@@ -22,7 +23,7 @@ pub trait Handler {
 /// Orders and filters options based on PARAMETER_REQUEST_LIST received from client.
 /// DHCP_MESSAGE_TYPE and SERVER_IDENTIFIER are always first and always retained.
 /// This function is called by Reply.
-pub fn filter_options_by_req(opts: &mut Vec<options::Option>, req_params: &[u8]) {
+pub fn filter_options_by_req(opts: &mut Vec<DhcpOption>, req_params: &[u8]) {
     let mut pos = 0;
     let h = &[options::DHCP_MESSAGE_TYPE as u8, options::SERVER_IDENTIFIER as u8, options::IP_ADDRESS_LEASE_TIME as u8] as &[u8];
     for z in [h, req_params].iter() {
@@ -80,18 +81,18 @@ impl Server {
     /// are added automatically.
     pub fn reply(&self,
                  msg_type: u8,
-                 additional_options: Vec<options::Option>,
+                 additional_options: Vec<DhcpOption>,
                  offer_ip: [u8; 4],
                  req_packet: Packet)
                  -> std::io::Result<usize> {
         let mt = &[msg_type];
 
-        let mut opts: Vec<options::Option> = Vec::with_capacity(additional_options.len() + 2);
-        opts.push(options::Option {
+        let mut opts: Vec<DhcpOption> = Vec::with_capacity(additional_options.len() + 2);
+        opts.push(DhcpOption {
             code: options::DHCP_MESSAGE_TYPE,
             data: mt,
         });
-        opts.push(options::Option {
+        opts.push(DhcpOption {
             code: options::SERVER_IDENTIFIER,
             data: &self.server_ip,
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,7 @@ pub struct Server {
 }
 
 pub trait Handler {
-    fn handle_request(&mut self, &Server, u8, Packet);
+    fn handle_request(&mut self, &Server, Packet);
 }
 
 /// Orders and filters options based on PARAMETER_REQUEST_LIST received from client.
@@ -63,13 +63,8 @@ impl Server {
                 Err(e) => return e,
                 Ok((l, src)) => {
                     if let Ok(p) = decode(&in_buf[..l]) {
-                        if let Some(msg_type) = p.option(options::DHCP_MESSAGE_TYPE) {
-                            if msg_type.len() != 1 {
-                                continue;
-                            }
-                            s.src = src;
-                            handler.handle_request(&s, msg_type[0], p);
-                        }
+                        s.src = src;
+                        handler.handle_request(&s, p);
                     }
                 }
             }


### PR DESCRIPTION
Create an `enum MessageType` to represent DHCP message types instead of `u8`, rename `Option` to `DhcpOption` to avoid confusion with `std::option::Option` and apply a few `rustfmt` changes in code that's being touched anyway.