### PR TITLE
Update to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dhcp4r"
 version = "0.1.0"
 authors = ["Richard Warburton <richard@warburton.it>"]
 description = "IPv4 DHCP library with working server example."
+edition = "2018"
 
 # These URLs point to more information about the repository.
 #documentation = "..."

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,4 @@
-use options::*;
+use crate::options::*;
 
 /// DHCP Packet Structure
 pub struct Packet<'a> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,9 +2,9 @@ use std::net::{UdpSocket, SocketAddr, Ipv4Addr, IpAddr};
 use std;
 use std::cell::Cell;
 
-use options::{DhcpOption, MessageType};
-use packet::*;
-use options;
+use crate::options::{DhcpOption, MessageType};
+use crate::packet::*;
+use crate::options;
 
 ///! This is a convenience module that simplifies the writing of a DHCP server service.
 
@@ -16,7 +16,7 @@ pub struct Server {
 }
 
 pub trait Handler {
-    fn handle_request(&mut self, &Server, Packet);
+    fn handle_request(&mut self, server: &Server, in_packet: Packet);
 }
 
 /// Orders and filters options based on PARAMETER_REQUEST_LIST received from client.


### PR DESCRIPTION
What it says on the tin.

I have some more ideas for changing some of the parameters from u8 slices to more semantically informative types (e.g. using std::net::Ipv4Addr for IP addresses), also I have a specific need to be able to select an interface to broadcast replies on (for a RPi which has WiFi and ethernet, where it's the DHCP server on the WiFi).

Point is, I was thinking of making a few minor changes, and I hear you're looking for a maintainer. I can't promise much, but I know a bit of Rust and I'd be willing to keep the lights on if you're still looking.
