### PR TITLE
Dev/upgrade nom 6 v0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["dhcp", "server", "monitor", "client"]
 license = "BSD-3-Clause"
 
 [dependencies]
-enum-primitive-derive = "^0.1"
-num-traits = "^0.1"
+enum-primitive-derive = "^0.2"
+num-traits = "^0.2"
 time = "0.1"
-nom = "5.0.1"
+nom = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ license = "BSD-3-Clause"
 [dependencies]
 enum-primitive-derive = "^0.2"
 num-traits = "^0.2"
-time = "0.1"
+time = "0.2"
 nom = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,7 @@ license = "BSD-3-Clause"
 [dependencies]
 enum-primitive-derive = "^0.2"
 num-traits = "^0.2"
-time = "0.2"
 nom = "6.0"
+
+[dev-dependencies]
+time = "0.2"

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -20,7 +20,7 @@ impl server::Handler for MyServer {
                     },
                     _ => in_packet.ciaddr,
                 };
-                println!("{}\t{}\t{}\tOnline", time::now().strftime("%Y-%m-%dT%H:%M:%S").unwrap(),
+                println!("{}\t{}\t{}\tOnline", time::OffsetDateTime::now_local().format("%Y-%m-%dT%H:%M:%S"),
                  chaddr(&in_packet.chaddr), Ipv4Addr::from(req_ip));
             }
             _ => {}


### PR DESCRIPTION
Hi,
This PR updates the dependencies (nom and time), with the following commits:
- Move time to dev-dependencies, only used in examples
- Upgrade time to 0.2
- Upgrade to nom 6

Could you look for a new release with updated dependencies? Thanks!