### PR TITLE
Bump nom version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "BSD-3-Clause"
 [dependencies]
 enum-primitive-derive = "^0.2"
 num-traits = "^0.2"
-nom = "6.0"
+nom = "7.0"
 
 [dev-dependencies]
 time = "0.2"


### PR DESCRIPTION
Rust now includes a <integer>::BITS definition in the std lib, that causes compiler errors in the lexical_core version used by nom.

This has been fixed in the new upstream versions.

Reference:
https://github.com/rust-lang/rust/issues/81654#issuecomment-771623079