### PR TITLE
map the subnet code to SubnetOption

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -1,13 +1,13 @@
 use num_traits::FromPrimitive;
 use std::net::Ipv4Addr;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct RawDhcpOption {
     pub code: u8,
     pub data: Vec<u8>,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum DhcpOption {
     DhcpMessageType(MessageType),
     ServerIdentifier(Ipv4Addr),
@@ -318,7 +318,7 @@ pub fn title(code: u8) -> Option<&'static str> {
 /// > This option is used to convey the type of the DHCP message.  The code for this option is 53,
 /// > and its length is 1.
 ///
-#[derive(Primitive, Copy, Clone, PartialEq)]
+#[derive(Primitive, Copy, Clone, PartialEq, Debug)]
 pub enum MessageType {
     /// Client broadcast to locate available servers.
     Discover = 1,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -25,6 +25,7 @@ impl<I> nom::error::ParseError<I> for Err<I> {
 type IResult<I, O> = nom::IResult<I, O, Err<I>>;
 
 /// DHCP Packet Structure
+#[derive(Debug)]
 pub struct Packet {
     pub reply: bool, // false = request, true = reply
     pub hops: u8,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -80,6 +80,7 @@ pub fn decode_option(input: &[u8]) -> IResult<&[u8], DhcpOption> {
         ROUTER => DhcpOption::Router(many0(decode_ipv4)(data)?.1),
         DOMAIN_NAME_SERVER => DhcpOption::DomainNameServer(many0(decode_ipv4)(data)?.1),
         IP_ADDRESS_LEASE_TIME => DhcpOption::IpAddressLeaseTime(be_u32(data)?.1),
+        SUBNET_MASK => DhcpOption::SubnetMask(decode_ipv4(data)?.1),
         MESSAGE => DhcpOption::Message(match std::str::from_utf8(data) {
             Ok(s) => s.to_string(),
             Err(_) => return Err(nom::Err::Error(Err::NonUtf8String)),

--- a/src/server.rs
+++ b/src/server.rs
@@ -128,7 +128,9 @@ impl Server {
     /// Checks the packet see if it was intended for this DHCP server (as opposed to some other also on the network).
     pub fn for_this_server(&self, packet: &Packet) -> bool {
         match packet.option(options::SERVER_IDENTIFIER) {
-            Some(DhcpOption::ServerIdentifier(x)) => (x == &self.server_ip),
+            Some(DhcpOption::ServerIdentifier(x)) => {
+                x == &self.server_ip
+            },
             _ => false,
         }
     }


### PR DESCRIPTION
Changes:
* Map `SUBNET` code to `DhcpOption::SubnetMask`.
* Add `Debug` to `DhcpOption` enum